### PR TITLE
Make sure list of missing columns is comma-separated

### DIFF
--- a/R/cumBg.R
+++ b/R/cumBg.R
@@ -95,7 +95,7 @@ cumBg <- function(
   # comp needs id (time) xCH4, time optional
   if(!is.null(comp) && class(comp)[1] == 'data.frame' && data.struct[1] == 'long') {
     if(any(missing.col <- !c(id.name, comp.name) %in% names(comp))){
-      stop('Specified column(s) in comp data frame (', deparse(substitute(comp)), ') not found: ', c(id.name, comp.name)[missing.col], '.')
+      stop('Specified column(s) in comp data frame (', deparse(substitute(comp)), ') not found: ', paste(c(id.name, comp.name)[missing.col], collapse=', '), '.')
     }
   }
 
@@ -104,12 +104,12 @@ cumBg <- function(
     if(any(!c(id.name, time.name, dat.name) %in% names(dat))){
       missing.col <- !c(id.name, time.name, dat.name) %in% names(dat)
       stop('Specified columns in dat data frame (', deparse(substitute(dat)), ') not found: ', paste(c(id.name, time.name, dat.name)[missing.col], collapse = ', '), '.')
-    } 
+    }
   } else if(data.struct[1] == 'wide') {
     if(any(!c(time.name, dat.name) %in% names(dat))){
       missing.col <- !c(time.name, dat.name) %in% names(dat)
       stop('Specified columns in dat data frame (', deparse(substitute(dat)), ') not found: ', paste(c(time.name, dat.name)[missing.col], collapse = ', '), '.')
-    } 
+    }
   }
 
   # Check for headspace argument if it is needed
@@ -429,7 +429,7 @@ cumBg <- function(
                             std.message = std.message)
         } else {
           dat$vBg <- dat[, dat.name]
-          message('Either temperature or presure is missing (temp and pres arguments) so volumes are NOT standardized.')
+          message('Either temperature or pressure is missing (temp and pres arguments) so volumes are NOT standardized.')
         }
       } else {
           dat$vBg <- dat[, dat.name]

--- a/R/cumBgDataPrep.R
+++ b/R/cumBgDataPrep.R
@@ -56,7 +56,7 @@ cumBgDataPrep <- function(
   # comp needs id (time) xCH4, time optional
   if(!is.null(comp) && class(comp)[1] == 'data.frame' && data.struct == 'long') {
     if(any(missing.col <- !c(id.name, comp.name) %in% names(comp))){
-      stop('Specified column(s) in comp data frame (', deparse(substitute(comp)), ') not found: ', c(id.name, comp.name)[missing.col], '.')
+      stop('Specified column(s) in comp data frame (', deparse(substitute(comp)), ') not found: ', paste(c(id.name, comp.name)[missing.col], collapse=', '), '.')
     }
   }
   
@@ -64,11 +64,11 @@ cumBgDataPrep <- function(
   if(data.struct %in% c('long', 'longcombo')) {
     if(any(missing.col <- !c(id.name, time.name, dat.name) %in% names(dat))){
       stop('Specified columns in dat data frame (', deparse(substitute(dat)), ') not found: ', paste(c(id.name, time.name, dat.name)[missing.col], collapse = ', '), '.')
-    } 
+    }
   } else if(data.struct == 'wide') {
     if(any(missing.col <- !c(time.name, dat.name) %in% names(dat))){
       stop('Specified columns in dat data frame (', deparse(substitute(dat)), ') not found: ', paste(c(time.name, dat.name)[missing.col], collapse = ', '), '.')
-    } 
+    }
   }
   
   # Rearrange wide data 

--- a/R/summBg.R
+++ b/R/summBg.R
@@ -207,18 +207,18 @@ summBg <- function(
   # Check for missing columns in vol
   if(class(when) %in% c('numeric', 'integer')) {
     if(any(missing.col <- !c(id.name, time.name, vol.name) %in% names(vol))){
-      stop('Specified columns in vol data frame (', deparse(substitute(vol)), ') not found: ', c(id.name, time.name, vol.name)[missing.col], '.')
-    } 
+      stop('Specified columns in vol data frame (', deparse(substitute(vol)), ') not found: ', paste(c(id.name, time.name, vol.name)[missing.col], collapse=', '), '.')
+    }
   } else { # when is 'end' or 'meas'
     if(any(missing.col <- !c(id.name, vol.name) %in% names(vol))){
-      stop('Specified columns in vol data frame (', deparse(substitute(vol)), ') not found: ', c(id.name, vol.name)[missing.col], '.')
-    } 
+      stop('Specified columns in vol data frame (', deparse(substitute(vol)), ') not found: ', paste(c(id.name, vol.name)[missing.col], collapse=', '), '.')
+    }
   }
 
   # Check for missing columns in setup
   if(any(missing.col <- !c(id.name, descrip.name) %in% names(setup))){
-    stop('Specified columns in setup data frame (', deparse(substitute(setup)), ') not found: ', c(id.name, descrip.name)[missing.col], '.')
-  } 
+    stop('Specified columns in setup data frame (', deparse(substitute(setup)), ') not found: ', paste(c(id.name, descrip.name)[missing.col], collapse=', '), '.')
+  }
 
   # Check that inoc.name and norm.name can be found in setup data frame
   if(!is.null(inoc.name) && !inoc.name %in% setup[, descrip.name]) {
@@ -236,7 +236,7 @@ summBg <- function(
 
   # Problem if inoc.name is given but inoc.m.name is not
   if(!is.null(inoc.name) & is.null(inoc.m.name)) {
-    stop('inoc.m.name must be provided in order to subtract inoculumn contribution.')
+    stop('inoc.m.name must be provided in order to subtract inoculum contribution.')
   }
 
   # Check for case when 'when' argument > all times


### PR DESCRIPTION
The list of missing columns in data frames are not always separated in summBg and cumBg{,DataPrep}. The attached changes fix this in the same way as it is done in other parts of the code. I also caught a couple of typos while working with the package.